### PR TITLE
Allow to configure additional jvm options

### DIFF
--- a/templates/es-client.yaml
+++ b/templates/es-client.yaml
@@ -84,7 +84,7 @@ spec:
           value: {{ $value | quote }}
         {{- end }}
         - name: "ES_JAVA_OPTS"
-          value: "-Xms{{ .Values.client.heapMemory }} -Xmx{{ .Values.client.heapMemory }}"
+          value: "-Xms{{ .Values.client.heapMemory }} -Xmx{{ .Values.client.heapMemory }} {{ .Values.client.javaOpts }}"
         - name: PROCESSORS
           valueFrom:
             resourceFieldRef:

--- a/templates/es-data.yaml
+++ b/templates/es-data.yaml
@@ -114,7 +114,7 @@ spec:
           value: "/podinfo/node-name"
         {{- end }}
         - name: ES_JAVA_OPTS
-          value: "-Xms{{ .Values.data.heapMemory }} -Xmx{{ .Values.data.heapMemory }}"
+          value: "-Xms{{ .Values.data.heapMemory }} -Xmx{{ .Values.data.heapMemory }} {{ .Values.data.javaOpts }}"
         {{- range $key, $value :=  .Values.common.env }}
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}

--- a/templates/es-master.yaml
+++ b/templates/es-master.yaml
@@ -89,7 +89,7 @@ spec:
           value: "/podinfo/node-name"
         {{- end }}
         - name: ES_JAVA_OPTS
-          value: "-Xms{{ .Values.master.heapMemory }} -Xmx{{ .Values.master.heapMemory }}"
+          value: "-Xms{{ .Values.master.heapMemory }} -Xmx{{ .Values.master.heapMemory }} {{ .Values.master.javaOpts }}"
         {{- range $key, $value :=  .Values.common.env }}
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -57,6 +57,10 @@ client:
   # OutOfMemoryErrors on startup.
   heapMemory: 256m
 
+  # Additional java options for elasticsearch JVM
+  # https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-system-settings.html#jvm-options
+  javaOpts: ""
+
   # When changing these values, make sure that *limits.cpu* is defined and
   # an integer. The usual kubernetes notation with millicores or fractions
   # does not work here!
@@ -101,6 +105,10 @@ data:
   # OutOfMemoryErrors on startup.
   heapMemory: 256m
 
+  # Additional java options for elasticsearch JVM
+  # https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-system-settings.html#jvm-options
+  javaOpts: ""
+
   # When changing these values, make sure that *limits.cpu* is defined and
   # an integer. The usual kubernetes notation with millicores or fractions
   # does not work here!
@@ -137,6 +145,10 @@ master:
   # same value as master.resources.requests.memory, or you may see
   # OutOfMemoryErrors on startup.
   heapMemory: 256m
+
+  # Additional java options for elasticsearch JVM
+  # https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-system-settings.html#jvm-options
+  javaOpts: ""
 
   # When changing these values, make sure that *limits.cpu* is defined and
   # an integer. The usual kubernetes notation with millicores or fractions


### PR DESCRIPTION
Add variable javaOpts for client, master or data-node to add additional JVM options to elasticsearch. Directly fills it's values to ES_JAVA_OPTS according to docs at https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-system-settings.html#jvm-options